### PR TITLE
feat: add source phase imports support to plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,21 @@
 {
-  "name": "acorn-plugin-import-defer",
+  "name": "acorn-import-phase",
   "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "acorn-plugin-import-defer",
+      "name": "acorn-import-phase",
       "version": "1.0.2",
       "license": "MIT",
       "devDependencies": {
-        "acorn": "^8.14.1"
+        "acorn": "^8.14.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "peerDependencies": {
+        "acorn": "^8.14.0"
       }
     },
     "node_modules/acorn": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "acorn-import-defer",
+  "name": "acorn-import-phase",
   "version": "1.0.2",
-  "description": "Support for `import defer` syntax in Acorn",
+  "description": "Support for `import <defer|source>` phase syntax in Acorn",
   "type": "module",
   "exports": {
     ".": {
@@ -17,6 +17,7 @@
     "acorn",
     "import",
     "defer",
+    "source phase",
     "proposal"
   ],
   "author": "Nicolò Ribaudo",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "acorn",
     "import",
     "defer",
-    "source phase",
+    "source",
+    "phase",
+    "wasm",
     "proposal"
   ],
   "author": "Nicolò Ribaudo",

--- a/src/plugin.cjs
+++ b/src/plugin.cjs
@@ -39,7 +39,7 @@ exports.plugin = function acornImportPhase(Parser, tt) {
         if (this.type !== tt.star) {
           this.raiseRecoverable(
             phaseId.start,
-            "'import defer' can only be used with namespace imports."
+            "'import defer' can only be used with namespace imports ('import defer * as identifierName from ...')."
           );
         }
       } else if (phase === "source") {
@@ -51,7 +51,16 @@ exports.plugin = function acornImportPhase(Parser, tt) {
         }
       }
 
-      return super.parseImportSpecifiers();
+      const specifiers =  super.parseImportSpecifiers();
+
+      if (phase === "source" && specifiers.some(s => s.type !== "ImportDefaultSpecifier")) {
+        this.raiseRecoverable(
+          phaseId.start,
+          `'import source' can only be used with direct identifier specifier imports ('import source identifierName from ...').`
+        );
+      }
+
+      return specifiers;
     }
 
     parseExprImport(forNew) {

--- a/src/plugin.cjs
+++ b/src/plugin.cjs
@@ -2,7 +2,7 @@
  * @param {typeof import("acorn").Parser} Parser
  * @param {typeof import("acorn").tokTypes} acorn
  */
-exports.plugin = function acornImportDefer(Parser, tt) {
+exports.plugin = function acornImportPhase(Parser, tt) {
   return class extends Parser {
     parseImport(node) {
       this._phase = null;
@@ -17,11 +17,11 @@ exports.plugin = function acornImportDefer(Parser, tt) {
       let phase = this.isContextual("defer") ? "defer" : this.isContextual("source") ? "source" : null;
       if (!phase) return super.parseImportSpecifiers();
 
-      const deferId = this.parseIdent();
+      const phaseId = this.parseIdent();
       if (this.isContextual("from") || this.type === tt.comma) {
-        const defaultSpecifier = this.startNodeAt(deferId.start, deferId.loc.start);
-        defaultSpecifier.local = deferId;
-        this.checkLValSimple(deferId, /* BIND_LEXICAL */ 2);
+        const defaultSpecifier = this.startNodeAt(phaseId.start, phaseId.loc.start);
+        defaultSpecifier.local = phaseId;
+        this.checkLValSimple(phaseId, /* BIND_LEXICAL */ 2);
 
         const nodes = [this.finishNode(defaultSpecifier, "ImportDefaultSpecifier")];
         if (this.eat(tt.comma)) {
@@ -38,14 +38,14 @@ exports.plugin = function acornImportDefer(Parser, tt) {
       if (phase === "defer") {
         if (this.type !== tt.star) {
           this.raiseRecoverable(
-            deferId.start,
+            phaseId.start,
             "'import defer' can only be used with namespace imports."
           );
         }
       } else if (phase === "source") {
         if (this.type !== tt.name) {
           this.raiseRecoverable(
-            deferId.start,
+            phaseId.start,
             "'import source' can only be used with direct identifier specifier imports."
           );
         }

--- a/test/fixtures/invalid-default/expected.json
+++ b/test/fixtures/invalid-default/expected.json
@@ -1,3 +1,3 @@
 {
-  "error": "'import defer' can only be used with namespace imports. (1:7)"
+  "error": "'import defer' can only be used with namespace imports ('import defer * as identifierName from ...'). (1:7)"
 }

--- a/test/fixtures/invalid-named/expected.json
+++ b/test/fixtures/invalid-named/expected.json
@@ -1,3 +1,3 @@
 {
-  "error": "'import defer' can only be used with namespace imports. (1:7)"
+  "error": "'import defer' can only be used with namespace imports ('import defer * as identifierName from ...'). (1:7)"
 }

--- a/test/fixtures/source-basic/actual.js
+++ b/test/fixtures/source-basic/actual.js
@@ -1,0 +1,1 @@
+import source foo from "x";

--- a/test/fixtures/source-basic/expected.json
+++ b/test/fixtures/source-basic/expected.json
@@ -1,0 +1,104 @@
+{
+  "type": "Program",
+  "start": 0,
+  "end": 28,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 0
+    }
+  },
+  "range": [
+    0,
+    28
+  ],
+  "body": [
+    {
+      "type": "ImportDeclaration",
+      "start": 0,
+      "end": 27,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 27
+        }
+      },
+      "range": [
+        0,
+        27
+      ],
+      "specifiers": [
+        {
+          "type": "ImportDefaultSpecifier",
+          "start": 14,
+          "end": 17,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 14
+            },
+            "end": {
+              "line": 1,
+              "column": 17
+            }
+          },
+          "range": [
+            14,
+            17
+          ],
+          "local": {
+            "type": "Identifier",
+            "start": 14,
+            "end": 17,
+            "loc": {
+              "start": {
+                "line": 1,
+                "column": 14
+              },
+              "end": {
+                "line": 1,
+                "column": 17
+              }
+            },
+            "range": [
+              14,
+              17
+            ],
+            "name": "foo"
+          }
+        }
+      ],
+      "source": {
+        "type": "Literal",
+        "start": 23,
+        "end": 26,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 23
+          },
+          "end": {
+            "line": 1,
+            "column": 26
+          }
+        },
+        "range": [
+          23,
+          26
+        ],
+        "value": "x",
+        "raw": "\"x\""
+      },
+      "phase": "source"
+    }
+  ],
+  "sourceType": "module"
+}

--- a/test/fixtures/source-dynamic/actual.js
+++ b/test/fixtures/source-dynamic/actual.js
@@ -1,0 +1,1 @@
+import.source("foo");

--- a/test/fixtures/source-dynamic/expected.json
+++ b/test/fixtures/source-dynamic/expected.json
@@ -1,0 +1,82 @@
+{
+  "type": "Program",
+  "start": 0,
+  "end": 22,
+  "loc": {
+    "start": {
+      "line": 1,
+      "column": 0
+    },
+    "end": {
+      "line": 2,
+      "column": 0
+    }
+  },
+  "range": [
+    0,
+    22
+  ],
+  "body": [
+    {
+      "type": "ExpressionStatement",
+      "start": 0,
+      "end": 21,
+      "loc": {
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 21
+        }
+      },
+      "range": [
+        0,
+        21
+      ],
+      "expression": {
+        "type": "ImportExpression",
+        "start": 0,
+        "end": 20,
+        "loc": {
+          "start": {
+            "line": 1,
+            "column": 0
+          },
+          "end": {
+            "line": 1,
+            "column": 20
+          }
+        },
+        "range": [
+          0,
+          20
+        ],
+        "source": {
+          "type": "Literal",
+          "start": 14,
+          "end": 19,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 14
+            },
+            "end": {
+              "line": 1,
+              "column": 19
+            }
+          },
+          "range": [
+            14,
+            19
+          ],
+          "value": "foo",
+          "raw": "\"foo\""
+        },
+        "phase": "source"
+      }
+    }
+  ],
+  "sourceType": "module"
+}

--- a/test/fixtures/source-invalid-named-after-default/actual.js
+++ b/test/fixtures/source-invalid-named-after-default/actual.js
@@ -1,0 +1,1 @@
+import source foo, { bar } from "x";

--- a/test/fixtures/source-invalid-named-after-default/expected.json
+++ b/test/fixtures/source-invalid-named-after-default/expected.json
@@ -1,0 +1,3 @@
+{
+  "error": "'import source' can only be used with direct identifier specifier imports ('import source identifierName from ...'). (1:7)"
+}

--- a/test/fixtures/source-invalid-named/actual.js
+++ b/test/fixtures/source-invalid-named/actual.js
@@ -1,0 +1,1 @@
+import source * as foo from "x";

--- a/test/fixtures/source-invalid-named/actual.js
+++ b/test/fixtures/source-invalid-named/actual.js
@@ -1,1 +1,1 @@
-import source * as foo from "x";
+import source { foo } from "x";

--- a/test/fixtures/source-invalid-named/expected.json
+++ b/test/fixtures/source-invalid-named/expected.json
@@ -1,0 +1,3 @@
+{
+  "error": "'import source' can only be used with direct identifier specifier imports. (1:7)"
+}

--- a/test/fixtures/source-invalid-ns/actual.js
+++ b/test/fixtures/source-invalid-ns/actual.js
@@ -1,0 +1,1 @@
+import source { foo } from "x";

--- a/test/fixtures/source-invalid-ns/actual.js
+++ b/test/fixtures/source-invalid-ns/actual.js
@@ -1,1 +1,1 @@
-import source { foo } from "x";
+import source * as foo from "x";

--- a/test/fixtures/source-invalid-ns/expected.json
+++ b/test/fixtures/source-invalid-ns/expected.json
@@ -1,0 +1,3 @@
+{
+  "error": "'import source' can only be used with direct identifier specifier imports. (1:7)"
+}

--- a/test/index.js
+++ b/test/index.js
@@ -19,7 +19,7 @@ const testFolders = readdirSync(resolve("./fixtures")).filter((file) =>
 
 const overwrite = process.env.OVERWRITE === "1";
 
-describe("acorn-import-defer", () => {
+describe("acorn-import-phase", () => {
   describe("esm", () => {
     runTests(acornESM, pluginESM);
   });
@@ -41,7 +41,6 @@ function runTests(acorn, plugin) {
       let result;
       try {
         const Parser = acorn.Parser.extend(plugin);
-        console.log(Parser)
         result = Parser.parse(actual, {
           ecmaVersion: 2024,
           locations: true,


### PR DESCRIPTION
Adds support for Source Phase Imports to this plugin, effectively turning it into a more general `import phase` plugin. Because `defer` and `source` are on a similar timeline at this point, this seems to make sense. Potentially configuration options could be used in future to handle other phases, or a new plugin could be used instead.